### PR TITLE
fix(android): change setOkHttpClientFactory for setCustomClientBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The certificate and password are expected to be loaded into the native Keychain 
 
 ## Usage
 
+### Ios
+
 Import the `MutualTLS` module, as well as the `Keychain` module.
 
 ```javascript
@@ -83,6 +85,20 @@ await MutualTLS.configure({
   keychainServiceForPassword: 'my-tls.client.p12.password',
 });
 ```
+
+### Android
+
+```javascript
+const myP12DataBase64 = "YOUR P12 FILE ENCODED AS BASE64 GOES HERE";
+const myPassword = "THE PASSWORD TO DECRYPT THE P12 FILE GOES HERE";
+
+MutualTLS.configure({
+  certificateFileP12: myP12DataBase64,
+  certificatePassword: myPassword,
+});
+```
+
+### Test
 
 Assuming you've done all that setup, then you're ready to make secure Mutual TLS requests with a server that is configured to trust the client certificate you provided.
 

--- a/android/src/main/java/com/reactlibrary/CustomClientFactory.java
+++ b/android/src/main/java/com/reactlibrary/CustomClientFactory.java
@@ -15,6 +15,7 @@ import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Arrays;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
@@ -78,16 +79,15 @@ public class CustomClientFactory implements OkHttpClientFactory {
                     .cookieJar(new ReactCookieJarContainer());
 
             // Enable TLS v1.3 and v1.2
-            ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                    .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
-                    .build();
+            // ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            //         .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+            //         .build();
 
-            builder.connectionSpecs(Arrays.asList(spec, ConnectionSpec.COMPATIBLE_TLS));
+            // builder.connectionSpecs(Arrays.asList(spec, ConnectionSpec.COMPATIBLE_TLS));
 
             builder.addInterceptor(new CustomInterceptor());
 
             return builder.build();
-
         } catch (Exception e) {
             Log.e(TAG, "Error creating OkHttpClient: " + e.getMessage());
             throw new RuntimeException("Failed to create OkHttpClient", e);

--- a/android/src/main/java/com/reactlibrary/MutualTLSModule.java
+++ b/android/src/main/java/com/reactlibrary/MutualTLSModule.java
@@ -5,7 +5,16 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.modules.network.OkHttpClientProvider;
+import com.facebook.react.modules.network.NetworkingModule;
+
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class MutualTLSModule extends ReactContextBaseJavaModule {
 
@@ -23,16 +32,23 @@ public class MutualTLSModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void configure(ReadableMap readableMap) {
-            String certificateFileP12 = readableMap.getString("certificateFileP12");
-            String certificatePassword = readableMap.getString("certificatePassword");
-            CustomClientFactory factory = new CustomClientFactory(certificateFileP12, certificatePassword);
-            OkHttpClientProvider.setOkHttpClientFactory(factory);
+        String certificateFileP12 = readableMap.getString("certificateFileP12");
+        String certificatePassword = readableMap.getString("certificatePassword");
+        CustomClientFactory factory = new CustomClientFactory(certificateFileP12, certificatePassword);
+        NetworkingModule.setCustomClientBuilder(builder -> {
+          OkHttpClient customClient = factory.createNewNetworkModuleClient();
+          builder.sslSocketFactory(customClient.sslSocketFactory(), (X509TrustManager) customClient.x509TrustManager());
+          builder.cookieJar(customClient.cookieJar());
+          builder.addInterceptor(customClient.interceptors().get(0));
+          builder.connectionSpecs(createConnectionSpecs());
+        });
     }
 
-
-    @ReactMethod
-    public void sampleMethod(String stringArgument, int numberArgument, Callback callback) {
-        // TODO: Implement some actually useful functionality
-        callback.invoke("Received numberArgument: " + numberArgument + " stringArgument: " + stringArgument);
+    private List<ConnectionSpec> createConnectionSpecs() {
+        // Enable TLS v1.3 and v1.2
+        ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+            .build();
+        return Arrays.asList(spec, ConnectionSpec.COMPATIBLE_TLS);
     }
 }


### PR DESCRIPTION
According to this issue: https://github.com/facebook/react-native/issues/34789 we can't override the `OkHttpClientFactory` factory after the app has started. So, we need to use `NetworkingModule.setCustomClientBuilder`.